### PR TITLE
feat: create route and update tweet_id decorator

### DIFF
--- a/src/classifier/classifier.controller.ts
+++ b/src/classifier/classifier.controller.ts
@@ -8,6 +8,7 @@ import {
   Delete,
   NotFoundException,
   HttpCode,
+  ValidationPipe,
 } from '@nestjs/common';
 import { ClassifierService, DifficultyStatistics, GroupStatistics } from './classifier.service';
 import { CreateClassifierDto } from './dto/create-classifier.dto';
@@ -27,6 +28,19 @@ export class ClassifierController {
   @ApiBody({ type: CreateClassifierDto })
   create(@Body() createClassifierDto: CreateClassifierDto): Promise<Classifier> {
     return this.classifierService.create(createClassifierDto);
+  }
+
+  @Post('multiple')
+  @ApiOperation({ summary: 'Create multiple classifiers for tweets' })
+  @ApiResponse({ status: 201, description: 'The classifiers have been successfully created.' })
+  @ApiResponse({ status: 400, description: 'Invalid input data.' })
+  @ApiResponse({ status: 404, description: 'One or more tweets not found.' })
+  @ApiBody({ type: [CreateClassifierDto] })
+  createMultiple(
+    @Body(new ValidationPipe({ whitelist: true, forbidNonWhitelisted: true }))
+    createClassifierDtos: CreateClassifierDto[],
+  ): Promise<Classifier[]> {
+    return this.classifierService.createMultiple(createClassifierDtos);
   }
 
   @Get()

--- a/src/classifier/classifier.controller.ts
+++ b/src/classifier/classifier.controller.ts
@@ -8,7 +8,6 @@ import {
   Delete,
   NotFoundException,
   HttpCode,
-  ValidationPipe,
 } from '@nestjs/common';
 import { ClassifierService, DifficultyStatistics, GroupStatistics } from './classifier.service';
 import { CreateClassifierDto } from './dto/create-classifier.dto';
@@ -36,10 +35,7 @@ export class ClassifierController {
   @ApiResponse({ status: 400, description: 'Invalid input data.' })
   @ApiResponse({ status: 404, description: 'One or more tweets not found.' })
   @ApiBody({ type: [CreateClassifierDto] })
-  createMultiple(
-    @Body(new ValidationPipe({ whitelist: true, forbidNonWhitelisted: true }))
-    createClassifierDtos: CreateClassifierDto[],
-  ): Promise<Classifier[]> {
+  createMultiple(@Body() createClassifierDtos: CreateClassifierDto[]): Promise<Classifier[]> {
     return this.classifierService.createMultiple(createClassifierDtos);
   }
 

--- a/src/classifier/classifier.service.ts
+++ b/src/classifier/classifier.service.ts
@@ -1,6 +1,6 @@
-import { Injectable } from '@nestjs/common';
+import { BadRequestException, Injectable } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
-import { Repository } from 'typeorm';
+import { ObjectLiteral, Repository } from 'typeorm';
 import { Classifier } from './classifier.entity';
 import { CreateClassifierDto } from './dto/create-classifier.dto';
 import { UpdateClassifierDto } from './dto/update-classifier.dto';
@@ -25,6 +25,85 @@ export class ClassifierService {
   async create(createClassifierDto: CreateClassifierDto): Promise<Classifier> {
     const classifier = this.classifierRepository.create(createClassifierDto);
     return await this.classifierRepository.save(classifier);
+  }
+
+  async createMultiple(createClassifierDtos: CreateClassifierDto[]): Promise<Classifier[]> {
+    // Check all members present in the classifier
+    const missingClassifiedGroup: CreateClassifierDto[] = [];
+    const missingClassifiedSubGroup: CreateClassifierDto[] = [];
+    const missingDifficulty: CreateClassifierDto[] = [];
+
+    createClassifierDtos.forEach((dto: CreateClassifierDto): void => {
+      if (!dto.tweet_id) {
+        throw new BadRequestException(
+          'Missing tweet_id in following classifier: ' + JSON.stringify(dto),
+        );
+      }
+      if (!dto.classified_group) {
+        missingClassifiedGroup.push(dto);
+      }
+      if (!dto.classified_sub_group) {
+        missingClassifiedSubGroup.push(dto);
+      }
+      if (!dto.difficulty) {
+        missingDifficulty.push(dto);
+      }
+    });
+
+    if (missingClassifiedGroup.length > 0) {
+      throw new BadRequestException(
+        'Missing classified_group in following classifiers: ' +
+          JSON.stringify(missingClassifiedGroup),
+      );
+    }
+
+    if (missingClassifiedSubGroup.length > 0) {
+      throw new BadRequestException(
+        'Missing classified_sub_group in following classifiers: ' +
+          JSON.stringify(missingClassifiedSubGroup),
+      );
+    }
+
+    if (missingDifficulty.length > 0) {
+      throw new BadRequestException(
+        'Missing difficulty in following classifiers: ' + JSON.stringify(missingDifficulty),
+      );
+    }
+
+    // Check if all tweets exist in tweets table
+    const tweetIds = createClassifierDtos.map((dto: CreateClassifierDto): string => dto.tweet_id);
+
+    // if tweets are not found, throw an error
+    const existingTweets = await this.classifierRepository.manager
+      .getRepository('Tweet')
+      .createQueryBuilder('tweet')
+      .where('tweet.tweet_id IN (:...tweetIds)', { tweetIds })
+      .getMany();
+
+    const existingTweetIds = existingTweets.map((tweet: ObjectLiteral): string => tweet.tweet_id);
+    const missingTweetIds = tweetIds.filter(
+      (id: string): boolean => !existingTweetIds.includes(id),
+    );
+
+    if (missingTweetIds.length > 0) {
+      throw new BadRequestException(
+        `The following tweet IDs do not exist in table Tweets: ${missingTweetIds.join(', ')}`,
+      );
+    }
+
+    // Find if there is any duplicate tweet_id in the input
+    const duplicateTweetIds = createClassifierDtos
+      .map((dto: CreateClassifierDto): string => dto.tweet_id)
+      .filter((id: string, index: number, self: string[]): boolean => self.indexOf(id) !== index);
+
+    if (duplicateTweetIds.length > 0) {
+      throw new BadRequestException(
+        `The following tweet IDs are duplicated in request: ${duplicateTweetIds.join(', ')}`,
+      );
+    }
+
+    const classifiers = this.classifierRepository.create(createClassifierDtos);
+    return await this.classifierRepository.save(classifiers);
   }
 
   async findAll(): Promise<Classifier[]> {

--- a/src/classifier/dto/create-classifier.dto.ts
+++ b/src/classifier/dto/create-classifier.dto.ts
@@ -1,13 +1,10 @@
-import { IsNotEmpty, IsString, IsNumber } from 'class-validator';
+import { IsNotEmpty, IsString } from 'class-validator';
 import { ApiProperty } from '@nestjs/swagger';
 
 export class CreateClassifierDto {
   @IsNotEmpty({ message: 'Tweet ID is required' })
-  @IsNumber(
-    { allowNaN: false, allowInfinity: false },
-    { message: 'Tweet ID must be a valid number' },
-  )
-  @ApiProperty({ example: 1234567890, description: 'Associated Tweet ID' })
+  @IsString({ message: 'Tweet ID must be a string' })
+  @ApiProperty({ example: '1234567890', description: 'Associated Tweet ID' })
   tweet_id: string;
 
   @IsNotEmpty({ message: 'Classified group is required' })

--- a/src/classifier/dto/create-classifier.dto.ts
+++ b/src/classifier/dto/create-classifier.dto.ts
@@ -19,6 +19,6 @@ export class CreateClassifierDto {
 
   @IsNotEmpty({ message: 'Difficulty level is required' })
   @IsString({ message: 'Difficulty must be a string' })
-  @ApiProperty({ example: 'High', description: 'Classification difficulty level' })
+  @ApiProperty({ example: '1', description: 'Classification difficulty level (1 - 5)' })
   difficulty: string;
 }

--- a/src/tweets/dto/create-tweet.dto.ts
+++ b/src/tweets/dto/create-tweet.dto.ts
@@ -1,13 +1,10 @@
-import { IsNotEmpty, IsString, IsNumber, IsOptional, IsDateString } from 'class-validator';
+import { IsNotEmpty, IsString, IsOptional, IsDateString } from 'class-validator';
 import { ApiProperty } from '@nestjs/swagger';
 
 export class CreateTweetDto {
   @IsNotEmpty({ message: 'Tweet ID must not be empty' })
-  @IsNumber(
-    { allowNaN: false, allowInfinity: false },
-    { message: 'Tweet ID must be a valid number' },
-  )
-  @ApiProperty({ example: 1234567890, description: 'Unique Tweet ID' })
+  @IsString({ message: 'Tweet ID must be a string' })
+  @ApiProperty({ example: '1234567890', description: 'Unique Tweet ID' })
   tweet_id: string;
 
   @IsString({ message: 'Tweet value must be a string' })


### PR DESCRIPTION
## Objective

Add new route classifiers to add in list

## General

<img width="1159" alt="Screenshot 2025-06-30 at 15 29 08" src="https://github.com/user-attachments/assets/f5983b46-5ffe-453d-bd53-f7c4cba32754" />

- If classifier already exist in table, will be updated (INSERT if not exist/UPDATE if exist)
- If classifier does not have all members, error will be raised (tweet_id, classified_group, classified_subgroup, difficulty are all required members)
- If in list has duplicated tweet_id, error will be raised
- If tweet_id doesn't exist in tweets, error will be raised